### PR TITLE
[#noissue] 상품 데이터 검색 성능 최적화 

### DIFF
--- a/src/main/java/project/trendpick_pro/domain/brand/entity/Brand.java
+++ b/src/main/java/project/trendpick_pro/domain/brand/entity/Brand.java
@@ -9,9 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Brand {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "brand_id")
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "name", nullable = false, unique = true)

--- a/src/main/java/project/trendpick_pro/domain/product/controller/ProductController.java
+++ b/src/main/java/project/trendpick_pro/domain/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package project.trendpick_pro.domain.product.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -62,8 +63,9 @@ public class ProductController {
     }
 
     @GetMapping("/keyword")
-    public ResponseEntity<Page<ProductListResponse>> searchQuery(@RequestParam(value = "query") String query,
-                                                                 @RequestParam(value = "page", defaultValue = "0") int offset) {
+    public ResponseEntity<Page<ProductListResponse>> searchQuery(
+            @Length(min = 2, max = 10, message = "검색어는 2자 이상 10자 이하로 입력해주세요.") @RequestParam(value = "query") String query,
+            @RequestParam(value = "page", defaultValue = "0") int offset) {
         return ResponseEntity.ok().body(productService.findAllByKeyword(query, offset));
     }
 

--- a/src/main/java/project/trendpick_pro/domain/product/entity/productOption/ProductOption.java
+++ b/src/main/java/project/trendpick_pro/domain/product/entity/productOption/ProductOption.java
@@ -11,15 +11,11 @@ import project.trendpick_pro.domain.category.entity.SubCategory;
 import project.trendpick_pro.domain.common.file.CommonFile;
 import project.trendpick_pro.domain.product.entity.product.ProductStatus;
 import project.trendpick_pro.domain.product.entity.productOption.dto.ProductOptionSaveRequest;
-import project.trendpick_pro.domain.tags.tag.entity.Tag;
 import project.trendpick_pro.global.exception.BaseException;
 import project.trendpick_pro.global.exception.ErrorCode;
 
-import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import static project.trendpick_pro.domain.product.entity.product.ProductStatus.SALE;
 import static project.trendpick_pro.domain.product.entity.product.ProductStatus.SOLD_OUT;

--- a/src/main/java/project/trendpick_pro/domain/product/service/ProductService.java
+++ b/src/main/java/project/trendpick_pro/domain/product/service/ProductService.java
@@ -128,7 +128,8 @@ public class ProductService {
     public Page<ProductListResponse> findAllByKeyword(String query, int offset) {
         ProductSearchCond cond = new ProductSearchCond(query);
         PageRequest pageable = PageRequest.of(offset, 18);
-        return productRepository.findAllByKeyword(cond, pageable);
+        Page<ProductListResponse> products = productRepository.findAllByKeyword(cond, pageable);
+        return products;
     }
 
     public List<Product> getRecommendProduct(Member member) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,9 @@ spring:
     url: jdbc:mysql://${DB_HOST:localhost}:3306/trendpick?rewriteBatchedStatements=true
     username: trendpick.application
     password: admin
+  sql:
+    init:
+      mode: always
   h2:
     console:
       enabled: true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,9 @@
+ALTER TABLE product DROP INDEX `title`;
+ALTER TABLE brand DROP INDEX `name`;
+ALTER TABLE main_category DROP INDEX `name`;
+ALTER TABLE sub_category DROP INDEX `name`;
+
+ALTER TABLE product ADD FULLTEXT INDEX `title` (`title`) VISIBLE;
+ALTER TABLE brand ADD FULLTEXT INDEX `name` (`name`) VISIBLE;
+ALTER TABLE main_category ADD FULLTEXT INDEX `name` (`name`) VISIBLE;
+ALTER TABLE sub_category ADD FULLTEXT INDEX `name` (`name`) VISIBLE;


### PR DESCRIPTION
#Issue
- resolve #

## 주요 변경점 
- LIKE 검색 대신 FULLTEXT 인덱스를 활용한 검색 쿼리로 전환하여, 키워드 기반의 문맥적 검색 가능.
- 검색 성능 테스트 결과, 새로운 쿼리는 1000만 건의 상품 데이터에 대한 검색 시간을 평균 12초에서 0.8~1.1초로 대폭 감소

## 구현 상세
- 상품, 브랜드, 메인 카테고리, 서브 카테고리에 대해 FULLTEXT 인덱스를 생성하여 검색 기능을 강화
- `MATCH() AGAINST()` 구문을 사용하여 각 컬럼에 대한 풀텍스트 검색이 가능하도록 하여, 검색 쿼리의 성능을 최적화
- 네이티브 쿼리 실행을 위한 `EntityManager`를 사용하여 쿼리 실행 방식을 전환
